### PR TITLE
Fix compatibility with ABP [Partial rules working]

### DIFF
--- a/AdBlockProtectorList.txt
+++ b/AdBlockProtectorList.txt
@@ -1,7 +1,9 @@
+[Adblock Plus 2.0]
 ! Title: AdBlock Protector List
 ! Ultimate solution against AdBlock detectors
-! By X01X012013
+! Author: X01X012013
 ! Version: 6.53
+! Expires: 1 days
 ! Homepage: https://x01x012013.github.io/AdBlockProtector/
 ! Support: https://github.com/X01X012013/AdBlockProtector/issues
 ! Download: https://github.com/X01X012013/AdBlockProtector/raw/master/AdBlockProtectorList.txt


### PR DESCRIPTION
Fixes "Not a valid filters list" error on ABP. There's no guaranty since the most of the rules are for **uBlock** only.
Feedback needed